### PR TITLE
Handle speed indicators for lines

### DIFF
--- a/srt_to_audition.py
+++ b/srt_to_audition.py
@@ -26,9 +26,15 @@ def get_frame_rate(video_file_path):
         print(f"Error extracting frame rate from video: {e}")
         sys.exit(1)
 
-# Main function to convert SRT to CSV format
+# Process subtitle text to extract and remove indicators like [FAST] or [FAST-ish]
+def process_subtitle_text(text):
+    match = re.match(r'\[(FAST|FAST-ish)\]\s*(.*)', text, re.I)
+    if match:
+        return match.group(2), match.group(1).upper()  # Return stripped text and the indicator
+    return text, ""  # Return original text and empty description if no indicator is found
+
+# Convert SRT file to CSV format with added functionality for indicators
 def convert_srt_to_csv(srt_file_path, video_file_path):
-    # Check if the provided SRT and video file paths exist
     if not os.path.exists(srt_file_path):
         print(f"The SRT file does not exist: {srt_file_path}")
         sys.exit(1)
@@ -36,13 +42,10 @@ def convert_srt_to_csv(srt_file_path, video_file_path):
         print(f"The video file does not exist: {video_file_path}")
         sys.exit(1)
 
-    # Get the frame rate from the video file
     fps = get_frame_rate(video_file_path)
-    # Define the output CSV file path
     csv_file_path = srt_file_path.replace('.srt', '.csv')
 
     try:
-        # Read the SRT file content
         with open(srt_file_path, 'r', encoding='utf-8') as file:
             srt_content = file.read()
     except Exception as e:
@@ -50,7 +53,6 @@ def convert_srt_to_csv(srt_file_path, video_file_path):
         sys.exit(1)
 
     try:
-        # Process the SRT content and generate CSV data
         entries = re.split(r'\n\n', srt_content.strip())
         csv_data = []
         for entry in entries:
@@ -61,17 +63,15 @@ def convert_srt_to_csv(srt_file_path, video_file_path):
                 start_time = str_to_timedelta(times[0])
                 end_time = str_to_timedelta(times[1])
                 duration = end_time - start_time
-                text = ' '.join(lines[2:]).replace('\n', ' ')
-                # Populate the CSV data dictionary
+                text, description = process_subtitle_text(' '.join(lines[2:]).replace('\n', ' '))
                 csv_data.append({
                     'Name': text,
                     'Start': timedelta_to_smpte_timecode(start_time, fps),
                     'Duration': timedelta_to_smpte_timecode(duration, fps),
                     'Time Format': f'{fps} fps',
                     'Type': 'Cue',
-                    'Description': ''  # Description remains empty
+                    'Description': description
                 })
-        # Write the CSV data to a file
         pd.DataFrame(csv_data).to_csv(csv_file_path, index=False, sep='\t', header=True)
         print(f"Converted SRT file saved to {csv_file_path}")
         print(f"The frame rate of the video is: {fps} fps")
@@ -79,21 +79,18 @@ def convert_srt_to_csv(srt_file_path, video_file_path):
         print(f"Error processing SRT file: {e}")
         sys.exit(1)
 
-# Function to get user input with a prompt
+# Get user input with a prompt
 def get_user_input(prompt):
     return input(prompt)
 
-# Main entry point of the script
+# Main script execution
 if __name__ == "__main__":
     if len(sys.argv) == 3:
-        # Use command-line arguments if provided
         srt_file_path = sys.argv[1]
         video_file_path = sys.argv[2]
     else:
-        # Enter interactive mode if command-line arguments are not provided
         print("You did not provide the required SRT and video file paths.")
         srt_file_path = get_user_input("Please enter the full path to the SRT file: ")
         video_file_path = get_user_input("Please enter the full path to the video file: ")
 
-    # Call the main conversion function with the provided paths
     convert_srt_to_csv(srt_file_path, video_file_path)


### PR DESCRIPTION
If a line start with either [FAST] or [FAST-ish] (even supports case insensitivity), these indicators will be stripped from the main cue name and added in the "Description" as a form of on-screen notes.